### PR TITLE
Made current code compliant with Maven style checker and PMD Analyzer

### DIFF
--- a/src/main/java/dev/coms4156/project/logprocessor/LogProcessorApplication.java
+++ b/src/main/java/dev/coms4156/project/logprocessor/LogProcessorApplication.java
@@ -3,6 +3,9 @@ package dev.coms4156.project.logprocessor;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+/**
+ * This is where the Spring Boot application for the Log Processor service is run.
+ */
 @SpringBootApplication
 public class LogProcessorApplication {
 

--- a/src/main/java/dev/coms4156/project/logprocessor/controller/AnalyticsController.java
+++ b/src/main/java/dev/coms4156/project/logprocessor/controller/AnalyticsController.java
@@ -1,31 +1,32 @@
 package dev.coms4156.project.logprocessor.controller;
 
-
-
 import dev.coms4156.project.logprocessor.service.LogService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-
-
-import org.springframework.web.bind.annotation.*;
-
+/**
+ * This file represents the AnalyticsController that provides insights about the top endpoints.
+ */
 @RestController
 @RequestMapping("/analytics")
 public class AnalyticsController {
 
-    private final LogService logService;
+  private final LogService logService;
 
-    public AnalyticsController(LogService logService) {
-        this.logService = logService;
-    }
+  public AnalyticsController(LogService logService) {
+    this.logService = logService;
+  }
 
-    /** Sample analytics endpoint to be replaced by more logic for security endpoints
-     * and features.
-     * /
-     * @return
-     */
-    @GetMapping("/top-endpoints")
-    public Object getTopEndpoints() {
-        return logService.getTopEndpoints();
-    }
+  /**
+   * Sample analytics endpoint to be replaced by more logic for security endpoints
+   * and features.
+   *
+   * @return Object topEndpoints
+   */
+  @GetMapping("/top-endpoints")
+  public Object getTopEndpoints() {
+    return logService.getTopEndpoints();
+  }
 }
 

--- a/src/main/java/dev/coms4156/project/logprocessor/controller/LogController.java
+++ b/src/main/java/dev/coms4156/project/logprocessor/controller/LogController.java
@@ -1,52 +1,63 @@
 package dev.coms4156.project.logprocessor.controller;
 
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.OK;
+
 import dev.coms4156.project.logprocessor.service.LogService;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-import static org.springframework.http.HttpStatus.*;
-
 import java.util.Map;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
+/**
+ * This file represents the endpoints associated with the LogService controller.
+ */
 @RestController
 @RequestMapping("/logs")
 public class LogController {
 
-    private final LogService logService;
+  private final LogService logService;
 
-    public LogController(LogService logService) {
-        this.logService = logService;
-    }
+  public LogController(LogService logService) {
+    this.logService = logService;
+  }
 
-    /**For client log upload into service.
-     * /
-     * @param clientId ID input by the client to differentiate rows in the database
-     * @param file apache log file in simple format to be parsed
-     * @return confirmation message
-     */
-    @PostMapping("/upload")
-    public String uploadLog(@RequestParam("clientId") String clientId, @RequestParam("file") MultipartFile file) {
-        try {
-            logService.processLogFile(file.getInputStream(), clientId);
-            return "Log file processed successfully.";
-        } catch (Exception e) {
-            e.printStackTrace();
-            return "Error processing log file: " + e.getMessage();
-        }
+  /**
+   * For client log upload into service.
+   *
+   * @param clientId ID input by the client to differentiate rows in the database
+   * @param file apache log file in simple format to be parsed
+   * @return confirmation message
+   */
+  @PostMapping("/upload")
+  public String uploadLog(@RequestParam("clientId") String clientId,
+                          @RequestParam("file") MultipartFile file) {
+    try {
+      logService.processLogFile(file.getInputStream(), clientId);
+      return "Log file processed successfully.";
+    } catch (Exception e) {
+      e.printStackTrace();
+      return "Error processing log file: " + e.getMessage();
     }
+  }
 
-    /**
-    * @param clientId ID input by the client to filter status codes.
-    * @return ResponseEntity containing counts of status codes for the given clientId,
-    * or an error message if the clientId is not found.
-    */
-    @GetMapping("/statusCodeCounts")
-    public ResponseEntity<?> getStatusCodeCounts(@RequestParam("clientId") String clientId) {
-        if (!logService.clientExists(clientId)) {
-            return new ResponseEntity<>("Error: clientId not found", NOT_FOUND);
-        }
-        Map<Integer, Integer> counts = logService.countStatusCodesForClient(clientId);
-        return new ResponseEntity<>(counts, OK);
+  /**
+   * This endpoint stores the frequency of each status code shown after processing.
+   *
+   * @param clientId ID input by the client to filter status codes.
+   * @return ResponseEntity containing counts of status codes for the given clientId,
+   *     or an error message if the clientId is not found.
+   */
+  @GetMapping("/statusCodeCounts")
+  public ResponseEntity<?> getStatusCodeCounts(@RequestParam("clientId") String clientId) {
+    if (!logService.clientExists(clientId)) {
+      return new ResponseEntity<>("Error: clientId not found", NOT_FOUND);
     }
+    Map<Integer, Integer> counts = logService.countStatusCodesForClient(clientId);
+    return new ResponseEntity<>(counts, OK);
+  }
 }

--- a/src/main/java/dev/coms4156/project/logprocessor/model/LogEntry.java
+++ b/src/main/java/dev/coms4156/project/logprocessor/model/LogEntry.java
@@ -1,8 +1,16 @@
 package dev.coms4156.project.logprocessor.model;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 
+/**
+ * This file represents the structure for a typical LogEntry.
+ */
 @Entity
 @Table(name = "log_entries")
 public class LogEntry {
@@ -27,8 +35,24 @@ public class LogEntry {
   private long responseSize;
   private LocalDateTime timestamp;
 
-  public LogEntry() {}
+  /**
+   * This is the empty LogEntry constructor.
+   */
+  public LogEntry() {
+      // Empty constructor with no arguments.
+  }
 
+  /**
+   * Parameterized LogEntry constructor.
+   *
+   * @param clientId ID input by the client.
+   * @param ipAddress IP Address provided by the client.
+   * @param method Method being invoked.
+   * @param endpoint Endpoint being invoked.
+   * @param statusCode Status code when the log entry is processed.
+   * @param responseSize Size of the response after the log entry is processed.
+   * @param timestamp Time when the log entry is processed.
+   */
   public LogEntry(String clientId, String ipAddress, String method, String endpoint,
                   int statusCode, long responseSize, LocalDateTime timestamp) {
     this.clientId = clientId;
@@ -41,21 +65,64 @@ public class LogEntry {
   }
 
   // --- Getters ---
-  public Long getId() { return id; }
-  public String getClientId() { return clientId; }
-  public String getIpAddress() { return ipAddress; }
-  public String getMethod() { return method; }
-  public String getEndpoint() { return endpoint; }
-  public int getStatusCode() { return statusCode; }
-  public long getResponseSize() { return responseSize; }
-  public LocalDateTime getTimestamp() { return timestamp; }
+  public Long getId() {
+    return id;
+  }
+
+  public String getClientId() {
+    return clientId;
+  }
+
+  public String getIpAddress() {
+    return ipAddress;
+  }
+
+  public String getMethod() {
+    return method;
+  }
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public int getStatusCode() {
+    return statusCode;
+  }
+
+  public long getResponseSize() {
+    return responseSize;
+  }
+
+  public LocalDateTime getTimestamp() {
+    return timestamp;
+  }
 
   // --- Setters (optional but safer for JPA) ---
-  public void setClientId(String clientId) { this.clientId = clientId; }
-  public void setIpAddress(String ipAddress) { this.ipAddress = ipAddress; }
-  public void setMethod(String method) { this.method = method; }
-  public void setEndpoint(String endpoint) { this.endpoint = endpoint; }
-  public void setStatusCode(int statusCode) { this.statusCode = statusCode; }
-  public void setResponseSize(long responseSize) { this.responseSize = responseSize; }
-  public void setTimestamp(LocalDateTime timestamp) { this.timestamp = timestamp; }
+  public void setClientId(String clientId) {
+    this.clientId = clientId;
+  }
+
+  public void setIpAddress(String ipAddress) {
+    this.ipAddress = ipAddress;
+  }
+
+  public void setMethod(String method) {
+    this.method = method;
+  }
+
+  public void setEndpoint(String endpoint) {
+    this.endpoint = endpoint;
+  }
+
+  public void setStatusCode(int statusCode) {
+    this.statusCode = statusCode;
+  }
+
+  public void setResponseSize(long responseSize) {
+    this.responseSize = responseSize;
+  }
+
+  public void setTimestamp(LocalDateTime timestamp) {
+    this.timestamp = timestamp;
+  }
 }

--- a/src/main/java/dev/coms4156/project/logprocessor/repository/LogEntryRepository.java
+++ b/src/main/java/dev/coms4156/project/logprocessor/repository/LogEntryRepository.java
@@ -1,10 +1,9 @@
 package dev.coms4156.project.logprocessor.repository;
 
 import dev.coms4156.project.logprocessor.model.LogEntry;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-
-import java.util.List;
 
 /**
  * Interface for communicating with the database. Jpa framework allows for some default
@@ -12,12 +11,13 @@ import java.util.List;
  */
 public interface LogEntryRepository extends JpaRepository<LogEntry, Long> {
 
-    @Query("SELECT l.endpoint, COUNT(l) FROM LogEntry l GROUP BY l.endpoint ORDER BY COUNT(l) DESC")
-    List<Object[]> findTopEndpoints();
+  @Query("SELECT l.endpoint, COUNT(l) FROM LogEntry l GROUP BY l.endpoint ORDER BY COUNT(l) DESC")
+  List<Object[]> findTopEndpoints();
 
-    @Query("SELECT l.statusCode, COUNT(l) FROM LogEntry l WHERE l.clientId = :clientId GROUP BY l.statusCode")
-    List<Object[]> countStatusCodesByClientId(String clientId);
+  @Query("SELECT l.statusCode, COUNT(l) FROM LogEntry l "
+          + "WHERE l.clientId = :clientId GROUP BY l.statusCode")
+  List<Object[]> countStatusCodesByClientId(String clientId);
 
-    // Check whether any entries exist for a given clientId
-    boolean existsByClientId(String clientId);
+  // Check whether any entries exist for a given clientId
+  boolean existsByClientId(String clientId);
 }

--- a/src/main/java/dev/coms4156/project/logprocessor/service/LogService.java
+++ b/src/main/java/dev/coms4156/project/logprocessor/service/LogService.java
@@ -2,95 +2,95 @@ package dev.coms4156.project.logprocessor.service;
 
 import dev.coms4156.project.logprocessor.model.LogEntry;
 import dev.coms4156.project.logprocessor.repository.LogEntryRepository;
-import org.springframework.stereotype.Service;
-
 import java.io.BufferedReader;
-import java.io.InputStreamReader;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+//import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Service;
 
-
-
+/**
+ * This file represents the endpoints for the LogService that processes different logs.
+ */
 @Service
 public class LogService {
 
+  private final LogEntryRepository repo;
 
-    private final LogEntryRepository repo;
+  public LogService(LogEntryRepository repo) {
+    this.repo = repo;
+  }
 
-    public LogService(LogEntryRepository repo) {
-        this.repo = repo;
-    }
+  // Simple Apache log pattern (combined format)
+  private static final Pattern LOG_PATTERN = Pattern.compile(
+        "^(\\S+) \\S+ \\S+ \\[(.+?)\\] \"(\\S+) (\\S+) \\S+\" (\\d{3}) (\\d+|-)"
+  );
 
-    // Simple Apache log pattern (combined format)
-    private static final Pattern LOG_PATTERN = Pattern.compile(
-            "^(\\S+) \\S+ \\S+ \\[(.+?)\\] \"(\\S+) (\\S+) \\S+\" (\\d{3}) (\\d+|-)"
-    );
+  /**
+   * Parses each log file extracting each component and creates a new LogEntry object.
+   * That LogEntry is saved into a LogEntryRepository which transfers its data into the
+   * database.
+   *
+   * @param fileStream input stream of the file given by the client
+   * @param clientId ID input by the client
+   * @throws Exception thrown if input stream cannot be read
+   */
+  public void processLogFile(InputStream fileStream, String clientId) throws Exception {
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(fileStream))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        Matcher matcher = LOG_PATTERN.matcher(line);
+        if (matcher.find()) {
+          String ip = matcher.group(1);
+          //String time = matcher.group(2);
+          String method = matcher.group(3);
+          String endpoint = matcher.group(4);
+          int status = Integer.parseInt(matcher.group(5));
+          long size = "-".equals(matcher.group(6)) ? 0 : Long.parseLong(matcher.group(6));
 
-    /**
-     * Parses each log file extracting each component and creates a new LogEntry object.
-     * That LogEntry is saved into a LogEntryRepository which transfers its data into the
-     * database.
-     * @param fileStream input stream of the file given by the client
-     * @param clientId ID input by the client
-     * @throws Exception thrown if input stream cannot be read
-     */
-    public void processLogFile(InputStream fileStream, String clientId) throws Exception {
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(fileStream))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                Matcher matcher = LOG_PATTERN.matcher(line);
-                if (matcher.find()) {
-                    String ip = matcher.group(1);
-                    String time = matcher.group(2);
-                    String method = matcher.group(3);
-                    String endpoint = matcher.group(4);
-                    int status = Integer.parseInt(matcher.group(5));
-                    long size = matcher.group(6).equals("-") ? 0 : Long.parseLong(matcher.group(6));
+          // Simplified timestamp parsing
+          LocalDateTime timestamp = LocalDateTime.now();
 
-                    // Simplified timestamp parsing
-                    LocalDateTime timestamp = LocalDateTime.now();
-
-                    LogEntry entry = new LogEntry(clientId, ip, method, endpoint, status, size, timestamp);
-                    repo.save(entry);
-                }
-            }
+          LogEntry entry = new LogEntry(clientId, ip, method, endpoint, status, size, timestamp);
+          repo.save(entry);
         }
+      }
     }
+  }
 
-    /**
-     * Sample method analytics to be replaced by security endpoint features
-     * @return object
-     */
-    public Object getTopEndpoints() {
-        return repo.findTopEndpoints();
+  /**
+   * Sample method analytics to be replaced by security endpoint features.
+   *
+   * @return object
+   */
+  public Object getTopEndpoints() {
+    return repo.findTopEndpoints();
+  }
+
+  /**
+   * Count status codes for entries matching the provided clientId.
+   * Returns a mapping from status code to count.
+   */
+  public Map<Integer, Integer> countStatusCodesForClient(String clientId) {
+    Map<Integer, Integer> result = new HashMap<>();
+    List<Object[]> rows = repo.countStatusCodesByClientId(clientId);
+    for (Object[] row : rows) {
+      Integer status = (Integer) row[0];
+      Long count = (Long) row[1];
+      result.put(status, count.intValue());
     }
+    return result;
+  }
 
-    /**
-     * Count status codes for entries matching the provided clientId.
-     * Returns a mapping from status code to count.
-     */
-    public Map<Integer, Integer> countStatusCodesForClient(String clientId) {
-        Map<Integer, Integer> result = new HashMap<>();
-        List<Object[]> rows = repo.countStatusCodesByClientId(clientId);
-        for (Object[] row : rows) {
-            Integer status = (Integer) row[0];
-            Long count = (Long) row[1];
-            result.put(status, count.intValue());
-        }
-        return result;
-    }
-
-    /**
-     * Returns true if at least one LogEntry exists for the provided clientId.
-     */
-    public boolean clientExists(String clientId) {
-        return repo.existsByClientId(clientId);
-    }
-
+  /**
+   * Returns true if at least one LogEntry exists for the provided clientId.
+   */
+  public boolean clientExists(String clientId) {
+    return repo.existsByClientId(clientId);
+  }
 }

--- a/src/test/java/dev/coms4156/project/logprocessor/controller/AnalyticsControllerTest.java
+++ b/src/test/java/dev/coms4156/project/logprocessor/controller/AnalyticsControllerTest.java
@@ -1,6 +1,16 @@
 package dev.coms4156.project.logprocessor.controller;
 
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import dev.coms4156.project.logprocessor.service.LogService;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -9,13 +19,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(AnalyticsController.class)
 @Import(AnalyticsControllerTest.MockConfig.class)
@@ -27,7 +30,7 @@ class AnalyticsControllerTest {
   @Autowired
   private LogService logService;
 
-  /** Modern Spring Boot 3.4+ mock configuration (replaces @MockBean) */
+  /** Modern Spring Boot 3.4+ mock configuration (replaces @MockBean). */
   static class MockConfig {
     @Bean
     LogService logService() {
@@ -41,9 +44,9 @@ class AnalyticsControllerTest {
     reset(logService);
   }
 
-  /** ✅ Test normal response with populated data */
+  /** Retrieve top endpoints with normal response and populated data. */
   @Test
-  void testGetTopEndpoints_ReturnsDataSuccessfully() throws Exception {
+  void testGetTopEndpointsReturnsDataSuccessfully() throws Exception {
     List<Object[]> mockData = new ArrayList<>();
     mockData.add(new Object[]{"endpoint1", 10L});
     mockData.add(new Object[]{"endpoint2", 5L});
@@ -57,9 +60,9 @@ class AnalyticsControllerTest {
     verify(logService, times(1)).getTopEndpoints();
   }
 
-  /** ✅ Test when the service returns an empty list */
+  /** Service returns an empty list. */
   @Test
-  void testGetTopEndpoints_EmptyList() throws Exception {
+  void testGetTopEndpointsEmptyList() throws Exception {
     when(logService.getTopEndpoints()).thenReturn(new ArrayList<>());
 
     mockMvc.perform(get("/analytics/top-endpoints"))

--- a/src/test/java/dev/coms4156/project/logprocessor/controller/LogControllerTest.java
+++ b/src/test/java/dev/coms4156/project/logprocessor/controller/LogControllerTest.java
@@ -1,6 +1,23 @@
 package dev.coms4156.project.logprocessor.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import dev.coms4156.project.logprocessor.service.LogService;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -10,14 +27,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(LogController.class)
 @Import(LogControllerTest.MockConfig.class)
@@ -29,7 +38,7 @@ class LogControllerTest {
   @Autowired
   private LogService logService;
 
-  /** ✅ Replacement for deprecated @MockBean (Spring Boot 3.4+) */
+  /** Replacement for deprecated @MockBean. */
   static class MockConfig {
     @Bean
     LogService logService() {
@@ -42,13 +51,12 @@ class LogControllerTest {
     reset(logService);
   }
 
-  /** ✅ Test successful file upload */
+  /** Test successful file upload. */
   @Test
-  void testUploadLog_Success() throws Exception {
+  void testUploadLogSuccess() throws Exception {
     MockMultipartFile mockFile =
             new MockMultipartFile("file", "log.txt", "text/plain", "dummy data".getBytes());
 
-    // No exception thrown by service
     doNothing().when(logService).processLogFile(any(), eq("clientA"));
 
     mockMvc.perform(multipart("/logs/upload")
@@ -60,9 +68,9 @@ class LogControllerTest {
     verify(logService, times(1)).processLogFile(any(), eq("clientA"));
   }
 
-  /** ✅ Test when LogService throws an exception */
+  /** LogService throws an exception. */
   @Test
-  void testUploadLog_Exception() throws Exception {
+  void testUploadLogException() throws Exception {
     MockMultipartFile mockFile =
             new MockMultipartFile("file", "log.txt", "text/plain", "invalid".getBytes());
 
@@ -73,15 +81,17 @@ class LogControllerTest {
     mockMvc.perform(multipart("/logs/upload")
                     .file(mockFile)
                     .param("clientId", "clientB"))
-            .andExpect(status().isOk()) // Controller always returns 200 with error message
-            .andExpect(content().string(org.hamcrest.Matchers.containsString("Error processing log file: Parsing failed")));
+            .andExpect(status().isOk())
+            .andExpect(content().string(
+                    org.hamcrest.Matchers.containsString(
+                            "Error processing log file: Parsing failed")));
 
     verify(logService, times(1)).processLogFile(any(), eq("clientB"));
   }
 
-  /** ✅ Test GET /statusCodeCounts returns OK with data */
+  /** GET /statusCodeCounts returns OK with data. */
   @Test
-  void testGetStatusCodeCounts_Found() throws Exception {
+  void testGetStatusCodeCountsFound() throws Exception {
     when(logService.clientExists("clientC")).thenReturn(true);
 
     Map<Integer, Integer> counts = new HashMap<>();
@@ -99,9 +109,9 @@ class LogControllerTest {
     verify(logService, times(1)).countStatusCodesForClient("clientC");
   }
 
-  /** ✅ Test GET /statusCodeCounts returns 404 when client not found */
+  /** GET /statusCodeCounts returns 404 when client not found. */
   @Test
-  void testGetStatusCodeCounts_NotFound() throws Exception {
+  void testGetStatusCodeCountsNotFound() throws Exception {
     when(logService.clientExists("missingClient")).thenReturn(false);
 
     mockMvc.perform(get("/logs/statusCodeCounts")

--- a/src/test/java/dev/coms4156/project/logprocessor/model/LogEntryUnitTests.java
+++ b/src/test/java/dev/coms4156/project/logprocessor/model/LogEntryUnitTests.java
@@ -11,41 +11,41 @@ import org.junit.jupiter.api.Test;
  */
 public class LogEntryUnitTests {
 
-    private static final String TEST_IP_ADDRESS = "test.ip.address";
+  private static final String TEST_IP_ADDRESS = "test.ip.address";
 
-    @Test
-    void noArgConstructorDefaultValues() {
-        LogEntry logEntry = new LogEntry();
+  @Test
+  void noArgConstructorDefaultValues() {
+    LogEntry logEntry = new LogEntry();
 
-        assertNull(logEntry.getId());
-        assertNull(logEntry.getClientId());
-        assertNull(logEntry.getIpAddress());
-        assertNull(logEntry.getMethod());
-        assertNull(logEntry.getEndpoint());
-        assertEquals(0, logEntry.getStatusCode());
-        assertEquals(0, logEntry.getResponseSize());
-        assertNull(logEntry.getTimestamp());
-    }
+    assertNull(logEntry.getId());
+    assertNull(logEntry.getClientId());
+    assertNull(logEntry.getIpAddress());
+    assertNull(logEntry.getMethod());
+    assertNull(logEntry.getEndpoint());
+    assertEquals(0, logEntry.getStatusCode());
+    assertEquals(0, logEntry.getResponseSize());
+    assertNull(logEntry.getTimestamp());
+  }
 
-    @Test
-    void parameterizedConstructorWithAllFields() {
-        String clientId = "testClient";
-        String ipAddress = TEST_IP_ADDRESS;
-        String method = "GET";
-        String endpoint = "/api/endpoint1";
-        int statusCode = 200;
-        long responseSize = 1024;
-        LocalDateTime timestamp = LocalDateTime.of(2025, 1, 1, 12, 0, 0);
-        LogEntry logEntry = new LogEntry(clientId,
-                ipAddress, method, endpoint, statusCode, responseSize, timestamp);
+  @Test
+  void parameterizedConstructorWithAllFields() {
+    String clientId = "testClient";
+    String ipAddress = TEST_IP_ADDRESS;
+    String method = "GET";
+    String endpoint = "/api/endpoint1";
+    int statusCode = 200;
+    long responseSize = 1024;
+    LocalDateTime timestamp = LocalDateTime.of(2025, 1, 1, 12, 0, 0);
+    LogEntry logEntry = new LogEntry(clientId,
+            ipAddress, method, endpoint, statusCode, responseSize, timestamp);
 
-        assertNull(logEntry.getId());
-        assertEquals(clientId, logEntry.getClientId());
-        assertEquals(ipAddress, logEntry.getIpAddress());
-        assertEquals(method, logEntry.getMethod());
-        assertEquals(endpoint, logEntry.getEndpoint());
-        assertEquals(statusCode, logEntry.getStatusCode());
-        assertEquals(responseSize, logEntry.getResponseSize());
-        assertEquals(timestamp, logEntry.getTimestamp());
-    }
+    assertNull(logEntry.getId());
+    assertEquals(clientId, logEntry.getClientId());
+    assertEquals(ipAddress, logEntry.getIpAddress());
+    assertEquals(method, logEntry.getMethod());
+    assertEquals(endpoint, logEntry.getEndpoint());
+    assertEquals(statusCode, logEntry.getStatusCode());
+    assertEquals(responseSize, logEntry.getResponseSize());
+    assertEquals(timestamp, logEntry.getTimestamp());
+  }
 }

--- a/src/test/java/dev/coms4156/project/logprocessor/repository/LogEntryRepositoryTest.java
+++ b/src/test/java/dev/coms4156/project/logprocessor/repository/LogEntryRepositoryTest.java
@@ -1,17 +1,16 @@
 package dev.coms4156.project.logprocessor.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import dev.coms4156.project.logprocessor.model.LogEntry;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ActiveProfiles("test")
@@ -20,17 +19,19 @@ class LogEntryRepositoryTest {
   @Autowired
   private LogEntryRepository repo;
 
-  private LogEntry e1, e2, e3, e4;
-
   @BeforeEach
   void setUp() {
     repo.deleteAll();
 
     // Build entities (id will auto-generate)
-    e1 = new LogEntry("clientA", "10.0.0.1", "GET", "/home", 200, 500L, LocalDateTime.now());
-    e2 = new LogEntry("clientA", "10.0.0.2", "GET", "/home", 200, 300L, LocalDateTime.now());
-    e3 = new LogEntry("clientA", "10.0.0.3", "POST", "/upload", 404, 0L, LocalDateTime.now());
-    e4 = new LogEntry("clientB", "10.0.0.4", "GET", "/info", 200, 100L, LocalDateTime.now());
+    LogEntry e1 = new LogEntry("clientA",
+            "XX.0.0.1", "GET", "/home", 200, 500L, LocalDateTime.now());
+    LogEntry e2 = new LogEntry("clientA",
+            "XX.0.0.2", "GET", "/home", 200, 300L, LocalDateTime.now());
+    LogEntry e3 = new LogEntry("clientA",
+            "XX.0.0.3", "POST", "/upload", 404, 0L, LocalDateTime.now());
+    LogEntry e4 = new LogEntry("clientB",
+            "XX.0.0.4", "GET", "/info", 200, 100L, LocalDateTime.now());
 
     repo.saveAll(List.of(e1, e2, e3, e4));
   }
@@ -42,7 +43,7 @@ class LogEntryRepositoryTest {
 
     assertThat(results).isNotEmpty();
     assertThat(results.get(0)[0]).isEqualTo("/home");
-    assertThat(((Long) results.get(0)[1])).isEqualTo(2L);
+    assertThat((Long) results.get(0)[1]).isEqualTo(2L);
 
     // Ensure all endpoints are present
     assertThat(results.stream().map(r -> (String) r[0]))

--- a/src/test/java/dev/coms4156/project/logprocessor/service/LogServiceTest.java
+++ b/src/test/java/dev/coms4156/project/logprocessor/service/LogServiceTest.java
@@ -1,17 +1,25 @@
 package dev.coms4156.project.logprocessor.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import dev.coms4156.project.logprocessor.model.LogEntry;
 import dev.coms4156.project.logprocessor.repository.LogEntryRepository;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.util.*;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 class LogServiceTest {
 
@@ -69,7 +77,7 @@ class LogServiceTest {
 
   @Test
   void testProcessLogFileParsesAndSaves() throws Exception {
-    String logLine = "127.0.0.1 - - [12/Oct/2025:06:25:24 +0000] \"GET /home HTTP/1.1\" 200 512";
+    String logLine = "XXX.0.0.1 - - [12/Oct/2025:06:25:24 +0000] \"GET /home HTTP/1.1\" 200 512";
     InputStream stream = new ByteArrayInputStream(logLine.getBytes());
 
     service.processLogFile(stream, "client123");
@@ -79,7 +87,7 @@ class LogServiceTest {
 
     LogEntry entry = captor.getValue();
     assertEquals("client123", entry.getClientId());
-    assertEquals("127.0.0.1", entry.getIpAddress());
+    assertEquals("XXX.0.0.1", entry.getIpAddress());
     assertEquals("GET", entry.getMethod());
     assertEquals("/home", entry.getEndpoint());
     assertEquals(200, entry.getStatusCode());

--- a/src/test/java/dev/coms4156/project/logprocessor/service/LogServiceUnitTests.java
+++ b/src/test/java/dev/coms4156/project/logprocessor/service/LogServiceUnitTests.java
@@ -26,83 +26,83 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class LogServiceUnitTests {
 
-    private static final String TEST_IP_ADDRESS = "test.ip.address";
+  private static final String TEST_IP_ADDRESS = "test.ip.address";
 
-    @Mock
-    private LogEntryRepository repo;
+  @Mock
+  private LogEntryRepository repo;
 
-    @InjectMocks
-    private LogService logService;
+  @InjectMocks
+  private LogService logService;
 
-    @Test
-    void processLogFileWithValidLogLines() throws Exception {
-        String clientId = "testClient";
-        String logLine = TEST_IP_ADDRESS + " - - [01/Jan/2025:12:00:00 +0000] \""
-                + "GET /api/endpoint1 HTTP/1.1\" 200 1024";
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(logLine.getBytes());
+  @Test
+  void processLogFileWithValidLogLines() throws Exception {
+    String clientId = "testClient";
+    String logLine = TEST_IP_ADDRESS + " - - [01/Jan/2025:12:00:00 +0000] \""
+            + "GET /api/endpoint1 HTTP/1.1\" 200 1024";
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(logLine.getBytes());
 
-        when(repo.save(any(LogEntry.class))).thenReturn(new LogEntry());
-        logService.processLogFile(inputStream, clientId);
-        verify(repo, times(1)).save(any(LogEntry.class));
+    when(repo.save(any(LogEntry.class))).thenReturn(new LogEntry());
+    logService.processLogFile(inputStream, clientId);
+    verify(repo, times(1)).save(any(LogEntry.class));
+  }
+
+  @Test
+  void processLogFileWithInvalidLogLines() throws Exception {
+    String clientId = "testClient";
+    String invalidLogLine = "invalid log line";
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(invalidLogLine.getBytes());
+
+    logService.processLogFile(inputStream, clientId);
+    verify(repo, times(0)).save(any(LogEntry.class));
+  }
+
+  @Test
+  void processLogFileWithEmptyLogFile() throws Exception {
+    String clientId = "testClient";
+    ByteArrayInputStream emptyInputStream = new ByteArrayInputStream("".getBytes());
+
+    logService.processLogFile(emptyInputStream, clientId);
+    verify(repo, times(0)).save(any(LogEntry.class));
+  }
+
+  @Test
+  void processLogFileWhereResponseSizeDashSetsZeroSize() throws Exception {
+    String clientId = "testClient";
+    String logLine = TEST_IP_ADDRESS + " - - [01/Jan/2025:12:00:00 +0000] \""
+            + "GET /api/endpoint1 HTTP/1.1\" 200 -";
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(logLine.getBytes());
+    when(repo.save(any(LogEntry.class))).thenReturn(new LogEntry());
+
+    logService.processLogFile(inputStream, clientId);
+    verify(repo, times(1)).save(any(LogEntry.class));
+  }
+
+  @Test
+  void processLogFileWithException() throws Exception {
+    String clientId = "testClient";
+    try (InputStream inputStream = new InputStream() {
+      @Override
+      public int read() throws IOException {
+        throw new IOException("Read error");
+      }
+    }) {
+      Exception exception = assertThrows(Exception.class, ()
+                -> logService.processLogFile(inputStream, clientId));
+      assertEquals("Read error", exception.getMessage());
+      verify(repo, times(0)).save(any(LogEntry.class));
     }
+  }
 
-    @Test
-    void processLogFileWithInvalidLogLines() throws Exception {
-        String clientId = "testClient";
-        String invalidLogLine = "invalid log line";
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(invalidLogLine.getBytes());
+  @Test
+  void getTopEndpointsReturnRepoResult() {
+    List<Object[]> mockTopEndpoints = Arrays.asList(
+            new Object[]{"/api/endpoint1", 100L},
+            new Object[]{"/api/endpoint2", 50L}
+    );
+    when(repo.findTopEndpoints()).thenReturn(mockTopEndpoints);
 
-        logService.processLogFile(inputStream, clientId);
-        verify(repo, times(0)).save(any(LogEntry.class));
-    }
-
-    @Test
-    void processLogFileWithEmptyLogFile() throws Exception {
-        String clientId = "testClient";
-        ByteArrayInputStream emptyInputStream = new ByteArrayInputStream("".getBytes());
-
-        logService.processLogFile(emptyInputStream, clientId);
-        verify(repo, times(0)).save(any(LogEntry.class));
-    }
-
-    @Test
-    void processLogFileWhereResponseSizeDashSetsZeroSize() throws Exception {
-        String clientId = "testClient";
-        String logLine = TEST_IP_ADDRESS + " - - [01/Jan/2025:12:00:00 +0000] \""
-                + "GET /api/endpoint1 HTTP/1.1\" 200 -";
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(logLine.getBytes());
-        when(repo.save(any(LogEntry.class))).thenReturn(new LogEntry());
-
-        logService.processLogFile(inputStream, clientId);
-        verify(repo, times(1)).save(any(LogEntry.class));
-    }
-
-    @Test
-    void processLogFileWithException() throws Exception {
-        String clientId = "testClient";
-        try (InputStream inputStream = new InputStream() {
-            @Override
-            public int read() throws IOException {
-                throw new IOException("Read error");
-            }
-        }) {
-            Exception exception = assertThrows(Exception.class, ()
-                    -> logService.processLogFile(inputStream, clientId));
-            assertEquals("Read error", exception.getMessage());
-            verify(repo, times(0)).save(any(LogEntry.class));
-        }
-    }
-
-    @Test
-    void getTopEndpointsReturnRepoResult() {
-        List<Object[]> mockTopEndpoints = Arrays.asList(
-                new Object[]{"/api/endpoint1", 100L},
-                new Object[]{"/api/endpoint2", 50L}
-        );
-        when(repo.findTopEndpoints()).thenReturn(mockTopEndpoints);
-
-        Object result = logService.getTopEndpoints();
-        assertEquals(mockTopEndpoints, result);
-        verify(repo, times(1)).findTopEndpoints();
-    }
+    Object result = logService.getTopEndpoints();
+    assertEquals(mockTopEndpoints, result);
+    verify(repo, times(1)).findTopEndpoints();
+  }
 }


### PR DESCRIPTION
- I had to change line 54 long size = "-".equals(matcher.group(6)) ? 0 : Long.parseLong(matcher.group(6)); in LogService.java due to the following PMD analyzer warning: Literals should be first in comparisons. If this line change causes issues, revert this change.

- Make sure to compile the program with mvn compile

- Run mvn checkstyle:check for the Maven checkstyle report

- Run pmd check -d src -R rulesets/java/quickstart.xml -f text -r pmd-report.txt to generate the PMD Analyzer report in a text file

- This is the only warning that appears in the program: src\main\java\dev\coms4156\project\logprocessor\LogProcessorApplication.java:10:	UseUtilityClass: All methods are static. Consider adding a private no-args constructor to prevent instantiation.

- This is a similar warning to the acceptable warning for the Spring Boot Application in the previous project

- Run mvn clean test and mvn jacoco:report to check the test coverage of the code